### PR TITLE
Pin jinja2 version with 3.0.3

### DIFF
--- a/changelogs/fragments/fix_jinja2_version.yaml
+++ b/changelogs/fragments/fix_jinja2_version.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Pin jinja2 version to 3.0.3.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible-core
 jsonschema
+Jinja2==3.0.3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
with any version above 3.0.3 jinja2 breaks with a importError

`An unhandled exception occurred while templating '/tmp/{{ ansible_date_time.iso8601_basic|hash('md5') }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: template error while templating string: cannot import name 'environmentfilter' from 'jinja2.filters' (/...)\n  line 0. String: /tmp/{{ ansible_date_time.iso8601_basic|hash('md5') }}`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
requirement 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
